### PR TITLE
Update source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.2",
-    "source-map": "^0.7.3"
+    "source-map": "^0.8.0-beta.0"
   },
   "description": "V8 stack traces with optional source map resolution.",
   "devDependencies": {


### PR DESCRIPTION
Firstly thanks very much for this excellent library.

# Problem
I am running a Nodejs app and am hitting the following error when using this library:
```
You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
```

# Diagnosis
* A dependency of yours "source-map" detects the runtime (Nodejs vs browser) in a broken way. That library then throws an exception if some client-side-specific code is not run.
* The "check" checks for the presence of a variable "fetch" and the reasonable thinking is that only browsers will have fetch. The issue is that in my case and in some others (see [here](https://github.com/mozilla/source-map/issues/349)) 3rd party libraries can define a variable "fetch" which triggers the described error.

# Tests
None