### PR TITLE
fix: improve source map resolution efficiency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - node
-  - 8
+  - 12
 script:
   - npm run lint
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
 script:
   - npm run lint
   - npm run test
+  - npm run build
   - npm run benchmark
   - NODE_ENV=test nyc --silent ava
   - nyc report --reporter=text-lcov | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
 node_js:
-  - node
+    # Fix Node 16 version to 16.2.0
+    # 16.3.0 is causing an issue with mock-fs library
+    # causing some unit tests in cauldron API to fail
+    # This is a temporary solution while waiting for
+    # this issue to be addressed by Node team in a new
+    # release and/or mock-fs library
+    # Reference : https://github.com/tschaub/mock-fs/issues/332
+  - 16.2.0
   - 12
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ node_js:
 script:
   - npm run lint
   - npm run test
+  - npm run benchmark
   - NODE_ENV=test nyc --silent ava
   - nyc report --reporter=text-lcov | coveralls
   - nyc check-coverage --lines 60

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "flow-copy-source": "^2.0.9",
     "husky": "^3.1.0",
     "mock-fs": "^5.0.0",
+    "nodemark": "^0.3.0",
     "nyc": "^14.1.1"
   },
   "engines": {
@@ -68,7 +69,8 @@
     "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps && flow-copy-source src dist",
     "dev": "NODE_ENV=production babel ./src --out-dir ./dist --copy-files --source-maps --watch",
     "lint": "eslint ./src ./test && flow",
-    "test": "NODE_ENV=test nyc ava --verbose --serial --concurrency 1"
+    "test": "NODE_ENV=test nyc ava --verbose --serial --concurrency 1",
+    "benchmark": "node performance/benchmark.js"
   },
   "version": "2.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "flow-bin": "^0.112.0",
     "flow-copy-source": "^2.0.9",
     "husky": "^3.1.0",
+    "mock-fs": "^5.0.0",
     "nyc": "^14.1.1"
   },
   "engines": {

--- a/performance/benchmark.js
+++ b/performance/benchmark.js
@@ -1,0 +1,14 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
+/* eslint-disable no-console */
+/* eslint-disable import/unambiguous */
+/* eslint-disable import/no-commonjs */
+const benchmark = require('nodemark');
+const {getStackTrace} = require('../dist');
+
+(async () => {
+  const result = await benchmark(async (callback) => {
+    await getStackTrace();
+    callback();
+  });
+  console.log(result);
+})();

--- a/performance/benchmark.js.map
+++ b/performance/benchmark.js.map
@@ -1,0 +1,15 @@
+{
+  "file": "min.js",
+  "mappings": "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
+  "names": [
+    "bar",
+    "baz",
+    "n"
+  ],
+  "sourceRoot": "http: //example.com/www/js/",
+  "sources": [
+    "one.js",
+    "two.js"
+  ],
+  "version": 3
+}

--- a/src/isReadableFile.js
+++ b/src/isReadableFile.js
@@ -2,12 +2,29 @@
 
 import fs from 'fs';
 
+const fileAccessCache: {
+  [string]: boolean | typeof undefined,
+  ...
+} = {};
+
 export default (filePath: string): boolean => {
+  // If the file was previously unreadable, we can assume this
+  // will always be the case
+  let accessable = fileAccessCache[filePath];
+
+  if (accessable !== undefined) {
+    return accessable;
+  }
+
   try {
     fs.accessSync(filePath, fs.constants.R_OK);
 
-    return true;
+    accessable = true;
   } catch (error) {
-    return false;
+    accessable = false;
   }
+
+  fileAccessCache[filePath] = accessable;
+
+  return accessable;
 };

--- a/test/resolveCallSiteSourceCode.js
+++ b/test/resolveCallSiteSourceCode.js
@@ -66,7 +66,7 @@ test('caches source maps once theyve been read', async (t) => {
     lineNumber: 1});
 });
 
-test('only attemps to access maps once', async (t) => {
+test('only attempts to access maps once', async (t) => {
   const callSite1 = await resolveCallSiteSourceCodeLocation({
     getColumnNumber: () => {
       return 28;

--- a/test/resolveCallSiteSourceCode.js
+++ b/test/resolveCallSiteSourceCode.js
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import path from 'path';
+import {promisify} from 'util';
+import mockfs from 'mock-fs';
+import test from 'ava';
+import resolveCallSiteSourceCodeLocation from '../src/resolveCallSiteSourceCodeLocation';
+
+const deleteFile = promisify(fs.unlink);
+const writeFile = promisify(fs.writeFile);
+
+const testSourceMap = {
+  file: 'min.js',
+  mappings: 'CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA',
+  names: [
+    'bar',
+    'baz',
+    'n',
+  ],
+  sourceRoot: 'http://example.com/www/js/',
+  sources: [
+    'one.js',
+    'two.js',
+  ],
+  version: 3,
+};
+
+mockfs({
+  node_modules:
+    mockfs.load('node_modules'),
+  'testsource.map': JSON.stringify(testSourceMap),
+});
+
+test('caches source maps once theyve been read', async (t) => {
+  const callSite1 = await resolveCallSiteSourceCodeLocation({
+    getColumnNumber: () => {
+      return 28;
+    },
+    getFileName: () => {
+      return 'testsource';
+    },
+    getLineNumber: () => {
+      return 2;
+    },
+  });
+
+  t.deepEqual(callSite1, {columnNumber: 10,
+    fileName: `${path.resolve(path.join(__dirname, '../'))}/http:/example.com/www/js/two.js`,
+    lineNumber: 2});
+
+  // // When we delete the map, we still expect the in memory map to be used
+  await deleteFile('testsource.map');
+
+  const callSite2 = await resolveCallSiteSourceCodeLocation({
+    getColumnNumber: () => {
+      return 10;
+    },
+    getFileName: () => {
+      return 'testsource';
+    },
+    getLineNumber: () => {
+      return 2;
+    },
+  });
+  t.deepEqual(callSite2, {columnNumber: 11,
+    fileName: `${path.resolve(path.join(__dirname, '../'))}/http:/example.com/www/js/two.js`,
+    lineNumber: 1});
+});
+
+test('only attemps to access maps once', async (t) => {
+  const callSite1 = await resolveCallSiteSourceCodeLocation({
+    getColumnNumber: () => {
+      return 28;
+    },
+    getFileName: () => {
+      return 'somesource';
+    },
+    getLineNumber: () => {
+      return 2;
+    },
+  });
+  t.deepEqual(callSite1, {columnNumber: 28,
+    fileName: 'somesource',
+    lineNumber: 2});
+
+  await writeFile('sourcesource', JSON.stringify(testSourceMap));
+
+  // We don't expect it to attempt to read this source map again
+  const callSite2 = await resolveCallSiteSourceCodeLocation({
+    getColumnNumber: () => {
+      return 28;
+    },
+    getFileName: () => {
+      return 'somesource';
+    },
+    getLineNumber: () => {
+      return 2;
+    },
+  });
+  t.deepEqual(callSite2, {columnNumber: 28,
+    fileName: 'somesource',
+    lineNumber: 2});
+});

--- a/test/resolveCallSiteSourceCode.js
+++ b/test/resolveCallSiteSourceCode.js
@@ -30,8 +30,8 @@ mockfs({
   'testsource.map': JSON.stringify(testSourceMap),
 });
 
-test('caches source maps once theyve been read', async (t) => {
-  const callSite1 = await resolveCallSiteSourceCodeLocation({
+test('caches original line results', async (t) => {
+  const callSite = {
     getColumnNumber: () => {
       return 28;
     },
@@ -41,29 +41,18 @@ test('caches source maps once theyve been read', async (t) => {
     getLineNumber: () => {
       return 2;
     },
-  });
+  };
+  const originalCallsite1 = await resolveCallSiteSourceCodeLocation(callSite);
 
-  t.deepEqual(callSite1, {columnNumber: 10,
+  t.deepEqual(originalCallsite1, {columnNumber: 10,
     fileName: `${path.resolve(path.join(__dirname, '../'))}/http:/example.com/www/js/two.js`,
     lineNumber: 2});
 
   // // When we delete the map, we still expect the in memory map to be used
   await deleteFile('testsource.map');
 
-  const callSite2 = await resolveCallSiteSourceCodeLocation({
-    getColumnNumber: () => {
-      return 10;
-    },
-    getFileName: () => {
-      return 'testsource';
-    },
-    getLineNumber: () => {
-      return 2;
-    },
-  });
-  t.deepEqual(callSite2, {columnNumber: 11,
-    fileName: `${path.resolve(path.join(__dirname, '../'))}/http:/example.com/www/js/two.js`,
-    lineNumber: 1});
+  const originalCallsite2 = await resolveCallSiteSourceCodeLocation(callSite);
+  t.deepEqual(originalCallsite2, originalCallsite1);
 });
 
 test('only attempts to access maps once', async (t) => {


### PR DESCRIPTION
Based on improvements described in #4 

- Cache file access results for source maps
- Cache original file locations for already known lines
- Use async readFile api for consuming source maps
- Update travis to test on node 12
- Provide performance benchmark script


## Performance

before
```
2,235 ops/sec ±1.28% (6601 samples)
```

after
```
18,294 ops/sec ±0.47% (53244 samples)
```